### PR TITLE
Thumbnails should be similar byte size as before, but 4 times the res…

### DIFF
--- a/models/image.go
+++ b/models/image.go
@@ -82,7 +82,7 @@ func (m *RecipeImageModel) save(imageInfo *RecipeImage, data []byte) (string, st
 	}
 
 	// Then generate a thumbnail image
-	thumbImage := imaging.Thumbnail(image, 250, 250, imaging.Box)
+	thumbImage := imaging.Thumbnail(image, 500, 500, imaging.NearestNeighbor)
 
 	// Use the EXIF data to determine the orientation of the original image.
 	// This data is lost when generating the thumbnail, so it's needed into
@@ -104,8 +104,9 @@ func (m *RecipeImageModel) save(imageInfo *RecipeImage, data []byte) (string, st
 			}
 		}
 	}
+
 	thumbBuf := new(bytes.Buffer)
-	err = imaging.Encode(thumbBuf, thumbImage, getImageFormat(contentType))
+	err = imaging.Encode(thumbBuf, thumbImage, getImageFormat(contentType), imaging.JPEGQuality(80))
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
…olution. Quality tradeoff is acceptable since detailed images (i.e. food)  tend to do better with jpeg compression